### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 AutoSimulationCraft
 ========================
 
-.. image:: https://pypip.in/v/autosimulationcraft/badge.png
+.. image:: https://img.shields.io/pypi/v/autosimulationcraft.svg
    :target: https://crate.io/packages/autosimulationcraft
 
 .. image:: http://jantman-personal-public.s3-website-us-east-1.amazonaws.com/pypi-stats/autosimulationcraft/per-month.svg


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20autosimulationcraft))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `autosimulationcraft`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.